### PR TITLE
Change Upload Call to Match Discord

### DIFF
--- a/EmoteReplacer.plugin.js
+++ b/EmoteReplacer.plugin.js
@@ -1440,7 +1440,9 @@
                 channelId: emote.channel,
                 file: new File([fileData], fullName),
                 draftType: 0,
-                message: { content: emote.content, invalidEmojis: [], tts: false, filename: fullName },
+                message: { content: emote.content, invalidEmojis: [], tts: false, channel_id: emote.channel },
+                hasSpoiler: 0,
+                filename: fullName,
             });
         }
 

--- a/EmoteReplacer.plugin.js
+++ b/EmoteReplacer.plugin.js
@@ -1436,14 +1436,12 @@
             // 5 = spoiler
             // 6 = filename
 
-            Uploader.upload(
-                emote.channel,
-                new File([fileData], fullName),
-                0,
-                { content: emote.content, invalidEmojis: [], tts: false },
-                emote.spoiler,
-                fullName
-            );
+            Uploader.upload({
+                channelId: emote.channel,
+                file: new File([fileData], fullName),
+                draftType: 0,
+                message: { content: emote.content, invalidEmojis: [], tts: false, filename: fullName },
+            });
         }
 
         compress(originalFile, commands, callback) {

--- a/EmoteReplacer.plugin.js
+++ b/EmoteReplacer.plugin.js
@@ -1441,7 +1441,7 @@
                 file: new File([fileData], fullName),
                 draftType: 0,
                 message: { content: emote.content, invalidEmojis: [], tts: false, channel_id: emote.channel },
-                hasSpoiler: 0,
+                hasSpoiler: emote.spoiler,
                 filename: fullName,
             });
         }


### PR DESCRIPTION
On Discord Canary (123267), it seems the upload method changed to accept an object with parameters, instead of splitting the parameters amongst multiple arguments.

Without the change, I get an error reading `Cannot read property 'name' of undefined`.

The upload method in Discord now looks like this:

```javascript
function C(e) {
            var t = e.channelId
              , n = e.file
              , i = e.draftType
              , s = e.message
              , c = {
                content: "",
                tts: !1,
                hasSpoiler: e.hasSpoiler,
                filename: e.filename
            };
           // and later, c's parameters get set to match s
          c.content = s.content;
          c.tts = s.tts;
          c.channel_id = s.channel_id;
          // ...
}
```

And so, the plugin now calls upload like this:
```javascript
Uploader.upload({
                channelId: emote.channel,
                file: new File([fileData], fullName),
                draftType: 0,
                message: { content: emote.content, invalidEmojis: [], tts: false, channel_id: emote.channel },
                hasSpoiler: 0,
                filename: fullName,
            });
}
```

The plugin now works for me with this change, but let me know if I've missed anything!