### PR TITLE
replace derive with manual Deserialize impl for Command

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -553,7 +553,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -739,9 +739,6 @@ name = "serde"
 version = "1.0.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c04e8343c3daeec41f58990b9d77068df31209f2af111e059e9fe9646693065"
-dependencies = [
- "serde_derive",
-]
 
 [[package]]
 name = "serde-wasm-bindgen"
@@ -752,17 +749,6 @@ dependencies = [
  "js-sys",
  "serde",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.159"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c614d17805b093df4b147b51339e7e44bf05ef59fba1e45d83500bcfb4d8585"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.13",
 ]
 
 [[package]]
@@ -804,17 +790,6 @@ name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -883,7 +858,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -905,7 +880,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 [dependencies]
 wasm-bindgen = "0.2.84"
 serde-wasm-bindgen = "0.5.0"
-serde = { version = "1.0.159", features = ["derive"] }
+serde = "1.0.159"
 image = "0.24.6"
 imageproc = "0.23.0"
 console_error_panic_hook = "0.1.7"

--- a/rust/src/command.rs
+++ b/rust/src/command.rs
@@ -1,0 +1,47 @@
+use std::fmt::{Formatter, Result as FmtResult};
+
+use serde::{
+    de::{Error as DeError, MapAccess, Visitor},
+    Deserialize, Deserializer,
+};
+
+pub struct Command {
+    pub name: String,
+    pub param: f32,
+}
+
+impl<'de> Deserialize<'de> for Command {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct CommandVisitor;
+
+        impl<'de> Visitor<'de> for CommandVisitor {
+            type Value = Command;
+
+            fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
+                f.write_str("a Command")
+            }
+
+            #[inline]
+            fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+                let mut name: Option<String> = None;
+                let mut param: Option<f32> = None;
+
+                // serde_wasm_bindgen's Deserializer unfortunately only deals with allocated Strings
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "name" => name = Some(map.next_value()?),
+                        "param" => param = Some(map.next_value()?),
+                        other => return Err(DeError::unknown_field(other, &["name", "param"])),
+                    }
+                }
+
+                Ok(Command {
+                    name: name.ok_or_else(|| DeError::missing_field("name"))?,
+                    param: param.ok_or_else(|| DeError::missing_field("param"))?,
+                })
+            }
+        }
+
+        d.deserialize_map(CommandVisitor)
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate console_error_panic_hook;
 
 use std::mem;
+use command::Command;
 use image::{codecs::gif::{GifEncoder, Repeat}, Frame};
 use infinite::infinite;
 use rain::rain;
@@ -16,6 +17,7 @@ use utils::{get_frames, get_delay};
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 use wiggle::wiggle;
 
+mod command;
 mod flip;
 mod rain;
 mod rainbow;
@@ -32,12 +34,6 @@ mod shake;
 extern "C" {
     #[wasm_bindgen(js_namespace = console)]
     fn log(s: &str);
-}
-
-#[derive(Deserialize)]
-struct Command {
-    pub name: String,
-    pub param: f32,
 }
 
 #[wasm_bindgen(js_name = "initPanicHook")]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -8,7 +8,6 @@ use rain::rain;
 use rainbow::rainbow;
 use resize::resize;
 use rotate::rotate;
-use serde::Deserialize;
 use flip::flip;
 use shake::shake;
 use slide::slide;


### PR DESCRIPTION
Reduces the expanded code size by about 200 LOC and removes `serde_derive` from the transitive dependencies.