### PR TITLE
collect instead of repeated push

### DIFF
--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -8,13 +8,10 @@ pub fn get_frames(data: &[u8], extension: &str) -> Result<Vec<Frame>, String> {
             let reader = GifDecoder::new(Cursor::new(data))
                 .map_err(|e| format!("Failed to create reader: {}", e))?;
 
-            let mut frames: Vec<Frame> = Vec::new();
-            for frame in reader.into_frames() {
-                let frame = frame.map_err(|e| format!("Failed to get next frame: {}", e))?;
-                frames.push(frame);
-            }
-
-            frames
+            reader
+                .into_frames()
+                .collect_frames()
+                .map_err(|e| format!("Failed to collect frames: {}", e))?
         },
         "png" => {
             let reader = PngDecoder::new(Cursor::new(data))


### PR DESCRIPTION
`.collect()` should generally be preferred over repeated `.push()` since those usually imply bound checks every time and gradual re-allocation.

`Result<_, _>` implements the `FromIterator` trait which means if you have an iterator over elements `Result<T, E>` one can collect that iterator into `Result<Vec<T>, E>` which is pretty neat. That's what happens in `.collect_frames()`.