### PR TITLE
replace to_rgba8 with into_rgba8

### DIFF
--- a/rust/src/utils.rs
+++ b/rust/src/utils.rs
@@ -22,7 +22,7 @@ pub fn get_frames(data: &[u8], extension: &str) -> Result<Vec<Frame>, String> {
 
             let mut image = DynamicImage::from_decoder(reader)
                 .map_err(|e| format!("Failed to create dynamic image: {}", e))?
-                .to_rgba8();
+                .into_rgba8();
 
             // GIFs only have one pixel value indicating transparency, so if alpha is 0 then change the pixel to that pixel value
             for pixel in image.pixels_mut() {


### PR DESCRIPTION
If the `DynamicImage` was already of type rgba then `to_rgba8()` would've cloned the underlying data since it only takes `&self`. `into_rgba8()` takes ownership instead so it can provide the data as is without cloning.