### PR TITLE
restructured commands as enum

### DIFF
--- a/rust/src/command.rs
+++ b/rust/src/command.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 pub struct Commands {
-    pub resize: Resize,
+    resize: Resize,
     commands: Vec<Command>,
 }
 
@@ -22,9 +22,13 @@ impl Commands {
     }
 
     pub fn apply(&self, frames: &mut Vec<Frame>) {
+        self.resize.apply_before_commands(frames);
+
         for command in self.commands.iter() {
             command.apply(frames);
         }
+
+        self.resize.apply_after_commands(frames);
     }
 }
 

--- a/rust/src/flip.rs
+++ b/rust/src/flip.rs
@@ -1,17 +1,22 @@
 use image::{imageops, Frame};
 
-enum Direction {
+#[derive(Copy, Clone)]
+pub enum Direction {
     Horizontal,
     Vertical,
 }
 
-pub fn flip(frames: &mut [Frame], direction: f32) {
-    let direction = if direction == 0.0 {
-        Direction::Horizontal
-    } else {
-        Direction::Vertical
-    };
+impl From<u8> for Direction {
+    fn from(value: u8) -> Self {
+        if value == 0 {
+            Self::Horizontal
+        } else {
+            Self::Vertical
+        }
+    }
+}
 
+pub fn flip(frames: &mut [Frame], direction: Direction) {
     for frame in frames {
         match direction {
             Direction::Horizontal => imageops::flip_horizontal_in_place(frame.buffer_mut()),

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -5,7 +5,6 @@ use image::codecs::gif::{GifEncoder, Repeat};
 use infinite::infinite;
 use rain::rain;
 use rainbow::rainbow;
-use resize::resize;
 use rotate::rotate;
 use flip::flip;
 use shake::shake;
@@ -54,15 +53,7 @@ pub fn apply_commands(data: Vec<u8>, extension: String, commands: JsValue) -> Re
         let mut writer = GifEncoder::new_with_speed(&mut output, 10);
         writer.set_repeat(Repeat::Infinite)?;
 
-        if commands.resize.pre_commands() {
-            resize(&mut frames, commands.resize);
-        }
-
         commands.apply(&mut frames);
-
-        if commands.resize.post_commands() {
-            resize(&mut frames, commands.resize);
-        }
 
         for frame in frames {
             writer.encode_frame(frame)?;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,8 +1,7 @@
 extern crate console_error_panic_hook;
 
-use std::mem;
-use command::Command;
-use image::{codecs::gif::{GifEncoder, Repeat}, Frame};
+use command::Commands;
+use image::codecs::gif::{GifEncoder, Repeat};
 use infinite::infinite;
 use rain::rain;
 use rainbow::rainbow;
@@ -12,7 +11,7 @@ use flip::flip;
 use shake::shake;
 use slide::slide;
 use spin::spin;
-use utils::{get_frames_and_scale, get_delay};
+use utils::get_frames;
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue, JsError};
 use wiggle::wiggle;
 
@@ -28,6 +27,7 @@ mod utils;
 mod slide;
 mod wiggle;
 mod shake;
+mod serde;
 
 #[wasm_bindgen]
 extern "C" {
@@ -42,43 +42,26 @@ pub fn init_panic_hook() {
 
 #[wasm_bindgen(js_name = "applyCommands")]
 pub fn apply_commands(data: Vec<u8>, extension: String, commands: JsValue) -> Result<Vec<u8>, JsError> {
-    let mut commands: Vec<Command> = serde_wasm_bindgen::from_value(commands)?;
+    let mut commands: Commands = serde_wasm_bindgen::from_value(commands)?;
 
-    let (mut frames, scale) = get_frames_and_scale(&data, &extension, &mut commands)?;
-    let overall_size = scale.0 * scale.1;
+    let Some(mut frames) = get_frames(&data, &extension, &mut commands)? else {
+        return Ok(data);
+    };
 
     let mut output = Vec::new();
+
     {
         let mut writer = GifEncoder::new_with_speed(&mut output, 10);
         writer.set_repeat(Repeat::Infinite)?;
 
-        if overall_size < 1.0  {
-            resize(&mut frames, scale);
+        if commands.resize.pre_commands() {
+            resize(&mut frames, commands.resize);
         }
 
-        for command in &commands {
-            let name = command.name.as_str();
-            match name {
-                "speed" => speed(&mut frames, command.param),
-                "hyperspeed" => hyperspeed(&mut frames),
-                "reverse" => reverse(&mut frames),
-                "flip" => flip(&mut frames, command.param),
-                "rain" => rain(&mut frames, command.param),
-                "rainbow" => rainbow(&mut frames, command.param),
-                "rotate" => rotate(&mut frames, command.param),
-                "spin" => spin(&mut frames, command.param, spin::Direction::Clockwise),
-                "spinrev" => spin(&mut frames, command.param, spin::Direction::CounterClockwise),
-                "infinite" => infinite(&mut frames, command.param),
-                "slide" => slide(&mut frames, command.param, slide::Direction::Forwards),
-                "sliderev" => slide(&mut frames, command.param, slide::Direction::Backwards),
-                "wiggle" => wiggle(&mut frames, command.param),
-                "shake" => shake(&mut frames, command.param),
-                _ => {},
-            };
-        }
+        commands.apply(&mut frames);
 
-        if overall_size > 1.0 {
-            resize(&mut frames, scale);
+        if commands.resize.post_commands() {
+            resize(&mut frames, commands.resize);
         }
 
         for frame in frames {
@@ -87,39 +70,4 @@ pub fn apply_commands(data: Vec<u8>, extension: String, commands: JsValue) -> Re
     };
 
     Ok(output)
-}
-
-fn speed(frames: &mut [Frame], value: f32) {
-    for frame in frames {
-        set_speed(frame, value as u32);
-    }
-}
-
-fn set_speed(frame: &mut Frame, speed: u32) {
-    let left = frame.left();
-    let top = frame.top();
-
-    *frame = Frame::from_parts(
-        mem::take(frame.buffer_mut()),
-        left,
-        top,
-        get_delay(speed),
-    );
-}
-
-fn hyperspeed(frames: &mut Vec<Frame>) {
-    if frames.len() <= 4 { return speed(frames, 2.0); }
-
-    let mut index = 0;
-    frames.retain_mut(|frame| {
-        let retain = index % 2 == 0;
-        if retain { set_speed(frame, 2); }
-
-        index += 1;
-        retain
-    });
-}
-
-fn reverse(frames: &mut [Frame]) {
-    frames.reverse();
 }

--- a/rust/src/rain.rs
+++ b/rust/src/rain.rs
@@ -4,9 +4,19 @@ use js_sys::Math;
 use crate::utils::{get_random_u32, align_gif, get_delay_centisecs, align_speed};
 
 #[derive(Copy, Clone)]
-enum RainType {
+pub enum RainType {
     Regular,
     Glitter,
+}
+
+impl From<u8> for RainType {
+    fn from(value: u8) -> Self {
+        if value == 0 {
+            Self::Regular
+        } else {
+            Self::Glitter
+        }
+    }
 }
 
 struct Drop {
@@ -99,14 +109,8 @@ impl Drop {
     }
 }
 
-pub fn rain(frames: &mut Vec<Frame>, rain_type: f32) {
+pub fn rain(frames: &mut Vec<Frame>, rain_type: RainType) {
     align_speed(frames, 8.0);
-
-    let rain_type = if rain_type == 0.0 {
-        RainType::Regular
-    } else {
-        RainType::Glitter
-    };
 
     let Some(frame) = frames.first() else { return; };
     let width = frame.buffer().width();

--- a/rust/src/resize.rs
+++ b/rust/src/resize.rs
@@ -1,22 +1,78 @@
-use image::{imageops::{self, FilterType}, Frame};
+use image::{
+    imageops::{self, FilterType},
+    Frame,
+};
 
-pub fn resize(frames: &mut [Frame], scale: (f32, f32)) {
+pub fn resize(frames: &mut [Frame], resize: Resize) {
     let Some(frame) = frames.first() else { return; };
     let width = frame.buffer().width() as f32;
     let height = frame.buffer().height() as f32;
 
-    let (scale_x, scale_y) = scale;
-    let target_width = (width * scale_x).round() as u32;
-    let target_height = (height * scale_y).round() as u32;
+    let scale = resize.scale();
+    let target_width = (width * scale.x).round() as u32;
+    let target_height = (height * scale.y).round() as u32;
 
     for frame in frames {
         let new_buffer = imageops::resize(
             frame.buffer(),
             target_width,
             target_height,
-            FilterType::Nearest
+            FilterType::Nearest,
         );
-        
+
         *frame.buffer_mut() = new_buffer;
+    }
+}
+
+#[derive(Copy, Clone, Default)]
+pub enum Resize {
+    Scale {
+        scale: f32,
+    },
+    Stretch {
+        scale_x: f32,
+        scale_y: f32,
+    },
+    #[default]
+    None,
+}
+
+pub struct Scale {
+    pub x: f32,
+    pub y: f32,
+}
+
+impl Resize {
+    pub fn requires_work(self) -> bool {
+        match self {
+            Resize::Scale { scale } => scale != 1.0,
+            Resize::Stretch { scale_x, scale_y } => scale_x != 1.0 || scale_y != 1.0,
+            Resize::None => false,
+        }
+    }
+
+    pub fn scale(self) -> Scale {
+        match self {
+            Resize::Scale { scale } => Scale { x: scale, y: scale },
+            Resize::Stretch { scale_x, scale_y } => Scale {
+                x: scale_x,
+                y: scale_y,
+            },
+            Resize::None => Scale { x: 1.0, y: 1.0 },
+        }
+    }
+
+    pub fn pre_commands(self) -> bool {
+        self.overall_size() < 1.0
+    }
+
+    pub fn post_commands(self) -> bool {
+        self.overall_size() > 1.0
+    }
+
+    pub fn overall_size(self) -> f32 {
+        let scales = self.scale();
+
+        scales.x * scales.y
     }
 }

--- a/rust/src/resize.rs
+++ b/rust/src/resize.rs
@@ -43,6 +43,18 @@ pub struct Scale {
 }
 
 impl Resize {
+    pub fn apply_before_commands(self, frames: &mut [Frame]) {
+        if self.overall_size() < 1.0 {
+            resize(frames, self);
+        }
+    }
+    
+    pub fn apply_after_commands(self, frames: &mut [Frame]) {
+        if self.overall_size() > 1.0 {
+            resize(frames, self);
+        }
+    }
+
     pub fn requires_work(self) -> bool {
         match self {
             Resize::Scale { scale } => scale != 1.0,
@@ -60,14 +72,6 @@ impl Resize {
             },
             Resize::None => Scale { x: 1.0, y: 1.0 },
         }
-    }
-
-    pub fn pre_commands(self) -> bool {
-        self.overall_size() < 1.0
-    }
-
-    pub fn post_commands(self) -> bool {
-        self.overall_size() > 1.0
     }
 
     pub fn overall_size(self) -> f32 {

--- a/rust/src/serde.rs
+++ b/rust/src/serde.rs
@@ -1,0 +1,217 @@
+use std::{
+    fmt::{Formatter, Result as FmtResult},
+    str::FromStr,
+};
+
+use serde::{
+    de::{Error as DeError, IgnoredAny, MapAccess, SeqAccess, Unexpected, Visitor},
+    Deserialize, Deserializer,
+};
+
+use crate::{
+    command::{Command, Commands},
+    resize::Resize,
+    slide, spin,
+};
+
+impl<'de> Deserialize<'de> for Commands {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct CommandsVisitor;
+
+        impl<'de> Visitor<'de> for CommandsVisitor {
+            type Value = Commands;
+
+            fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
+                f.write_str("a sequence of Commands")
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+                let mut commands = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+                let mut resize = None;
+
+                while let Some(elem) = seq.next_element()? {
+                    match elem {
+                        CommandOrResize::Command(command) => commands.push(command),
+                        CommandOrResize::Resize(resize_) => resize = Some(resize_),
+                    }
+                }
+
+                let resize = resize.unwrap_or_default();
+
+                Ok(Commands::new(commands, resize))
+            }
+        }
+
+        d.deserialize_seq(CommandsVisitor)
+    }
+}
+
+enum CommandOrResize {
+    Command(Command),
+    Resize(Resize),
+}
+
+impl<'de> Deserialize<'de> for CommandOrResize {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct CommandVisitor;
+
+        impl<'de> Visitor<'de> for CommandVisitor {
+            type Value = CommandOrResize;
+
+            fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
+                f.write_str("a Command")
+            }
+
+            fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<Self::Value, A::Error> {
+                let key: String = map
+                    .next_key()?
+                    .ok_or_else(|| DeError::custom("unexpected empty map"))?;
+
+                if key != "name" {
+                    return Err(DeError::custom(
+                        "deserialization requires \"name\" as first field",
+                    ));
+                }
+
+                let name: String = map.next_value()?;
+
+                fn parse_param<'de, T, A>(map: &mut A) -> Result<T, A::Error>
+                where
+                    T: FromStr,
+                    A: MapAccess<'de>,
+                {
+                    let (_, param) = map
+                        .next_entry::<IgnoredAny, String>()?
+                        .ok_or_else(|| DeError::missing_field("param"))?;
+
+                    param
+                        .parse()
+                        .map_err(|_| DeError::custom(format!("failed to parse param `{param}`")))
+                }
+
+                match name.as_str() {
+                    "flip" => {
+                        let direction: u8 = parse_param(&mut map)?;
+
+                        Ok(CommandOrResize::Command(Command::Flip {
+                            direction: direction.into(),
+                        }))
+                    }
+                    "hyperspeed" => Ok(CommandOrResize::Command(Command::Hyperspeed)),
+                    "infinite" => {
+                        let speed = parse_param(&mut map)?;
+
+                        Ok(CommandOrResize::Command(Command::Infinite { speed }))
+                    }
+                    "rain" => {
+                        let ty: u8 = parse_param(&mut map)?;
+
+                        Ok(CommandOrResize::Command(Command::Rain { ty: ty.into() }))
+                    }
+                    "rainbow" => {
+                        let speed = parse_param(&mut map)?;
+
+                        Ok(CommandOrResize::Command(Command::Rainbow { speed }))
+                    }
+                    "reverse" => Ok(CommandOrResize::Command(Command::Reverse)),
+                    "resize" => {
+                        let (_, resize) = map
+                            .next_entry::<IgnoredAny, Resize>()?
+                            .ok_or_else(|| DeError::missing_field("param"))?;
+
+                        Ok(CommandOrResize::Resize(resize))
+                    }
+                    "rotate" => {
+                        let degrees = parse_param(&mut map)?;
+
+                        Ok(CommandOrResize::Command(Command::Rotate { degrees }))
+                    }
+                    "shake" => {
+                        let strength = parse_param(&mut map)?;
+
+                        Ok(CommandOrResize::Command(Command::Shake { strength }))
+                    }
+                    "slide" => {
+                        let speed = parse_param(&mut map)?;
+
+                        Ok(CommandOrResize::Command(Command::Slide {
+                            direction: slide::Direction::Forwards,
+                            speed,
+                        }))
+                    }
+                    "sliderev" => {
+                        let speed = parse_param(&mut map)?;
+
+                        Ok(CommandOrResize::Command(Command::Slide {
+                            direction: slide::Direction::Backwards,
+                            speed,
+                        }))
+                    }
+                    "speed" => {
+                        let value = parse_param(&mut map)?;
+
+                        Ok(CommandOrResize::Command(Command::Speed { value }))
+                    }
+                    "spin" => {
+                        let speed = parse_param(&mut map)?;
+
+                        Ok(CommandOrResize::Command(Command::Spin {
+                            direction: spin::Direction::Clockwise,
+                            speed,
+                        }))
+                    }
+                    "spinrev" => {
+                        let speed = parse_param(&mut map)?;
+
+                        Ok(CommandOrResize::Command(Command::Spin {
+                            direction: spin::Direction::CounterClockwise,
+                            speed,
+                        }))
+                    }
+                    "wiggle" => {
+                        let speed = parse_param(&mut map)?;
+
+                        Ok(CommandOrResize::Command(Command::Wiggle { speed }))
+                    }
+                    _ => Err(DeError::custom(format!("unknown command name `{name}`"))),
+                }
+            }
+        }
+
+        d.deserialize_map(CommandVisitor)
+    }
+}
+
+impl<'de> Deserialize<'de> for Resize {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        struct ResizeVisitor;
+
+        impl<'de> Visitor<'de> for ResizeVisitor {
+            type Value = Resize;
+
+            fn expecting(&self, f: &mut Formatter<'_>) -> FmtResult {
+                f.write_str("a resize value")
+            }
+
+            fn visit_str<E: DeError>(self, v: &str) -> Result<Self::Value, E> {
+                match v.split_once('x') {
+                    None => Ok(Resize::Scale {
+                        scale: v.parse().map_err(|_| {
+                            DeError::invalid_value(Unexpected::Str(v), &"a stringified number")
+                        })?,
+                    }),
+                    Some((x, y)) => Ok(Resize::Stretch {
+                        scale_x: x.parse().map_err(|_| {
+                            DeError::invalid_value(Unexpected::Str(x), &"a stringified number")
+                        })?,
+                        scale_y: y.parse().map_err(|_| {
+                            DeError::invalid_value(Unexpected::Str(y), &"a stringified number")
+                        })?,
+                    }),
+                }
+            }
+        }
+
+        d.deserialize_str(ResizeVisitor)
+    }
+}

--- a/rust/src/spin.rs
+++ b/rust/src/spin.rs
@@ -2,6 +2,7 @@ use image::Frame;
 
 use crate::{rotate::rotate_frame, utils::{align_gif, get_delay_centisecs, align_speed}};
 
+#[derive(Copy, Clone)]
 pub enum Direction {
     Clockwise,
     CounterClockwise


### PR DESCRIPTION
Restructured commands a bunch.
All parsing messiness happens while deserializing in `serde.rs` so that other parts become cleaner.
Not quite sure if this is an improvement, you be the judge.