### PR TITLE
Add ability to send images as links

### DIFF
--- a/src/pluginConstants.ts
+++ b/src/pluginConstants.ts
@@ -21,6 +21,7 @@ export const DEFAULT_SETTINGS = {
   autocompleteEmoteSize: 15,
   autocompleteItems: 10,
   customEmotes: {},
+  sendAsLink,
   requirePrefix: true,
   prefix: ';',
   resizeMethod: 'largest',

--- a/src/services/sendMessageService.ts
+++ b/src/services/sendMessageService.ts
@@ -75,13 +75,33 @@ export class SendMessageService extends BaseService {
       foundEmote.channel = channelId;
 
       try {
-        if (!this.attachService.canAttach) {
-          throw new Error('This channel does not allow sending images!');
-        }
-
-        this.attachService.pendingUpload = this.fetchBlobAndUpload(foundEmote);
-        await this.attachService.pendingUpload;
-        return;
+		if (!this.attachService.canAttach) {
+		  throw new Error('This channel does not allow sending images!');
+		}
+		if(this.settingsService.settings.sendAsLink) {
+		  let contentBefore = args[1].content.substring(0, foundEmote.pos);
+		  let emojiContent = foundEmote.url + `?size=${this.settingsService.settings.emoteSize}`;
+		  let contentAfter = args[1].content.substring(foundEmote.pos + foundEmote.emoteLength, args[1].content.length);
+		  
+		  if(contentBefore) {
+		    args[1].content = contentBefore;
+		    await callDefault(...args);
+		  }
+		  if(emojiContent) {
+		    args[1].content = emojiContent;
+		    await callDefault(...args);
+		  }
+		  if(contentAfter) {
+		    args[1].content = contentAfter;
+		    await callDefault(...args);
+		  }
+		}
+		else {
+			this.attachService.pendingUpload = this.fetchBlobAndUpload(foundEmote);
+			await this.attachService.pendingUpload;
+		}
+		
+		return;
       } catch (error: unknown) {
         const errorMessage = error instanceof Error ? error.message : (error as string);
 

--- a/src/services/settingsService.ts
+++ b/src/services/settingsService.ts
@@ -269,6 +269,17 @@ export class SettingsService extends BaseService {
       },
     });
     settings.push(autocompleteItems);
+	
+	const sendAsLink = Utils.SwitchSetting({
+      id: 'sendAsLink',
+      name: 'Send as link',
+      note: 'If this is enabled, the images will be sent as links instead of images.',
+      value: this.settings.sendAsLink,
+      onChange: (checked) => {
+        this.settings.sendAsLink = checked;
+      },
+    });
+    settings.push(sendAsLink);
 
     const requirePrefix = Utils.SwitchSetting({
       id: 'requirePrefix',


### PR DESCRIPTION
I've been using this extension for a long time. I added ability to send images as links at one point, because then it works much quicker and also at some point images that are sent as images are lower quality than images that are sent as links. Here's the comparison between the two:
![image](https://github.com/user-attachments/assets/6e917c7c-855f-4a0f-9956-4b747c4c67dc)

I usually added changes to the compiled javascript file and decided to finally create a pull request. But I didn't build the project from sources, I only tested it on the compiled javascript file.

As you can see, in my send as link change, I also separate the content before and after from sending the image itself.